### PR TITLE
Adjusted TransportBuilder prepareMessage method to support text/plain…

### DIFF
--- a/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
+++ b/lib/internal/Magento/Framework/Mail/Template/TransportBuilder.php
@@ -394,7 +394,12 @@ class TransportBuilder
         }
 
         /** @var \Magento\Framework\Mail\MimePartInterface $mimePart */
-        $mimePart = $this->mimePartInterfaceFactory->create(['content' => $content]);
+         $mimePart = $this->mimePartInterfaceFactory->create(
+        	[
+        		'content' => $content,
+        		'type' => $part['type']
+        	]
+        );
         $this->messageData['encoding'] = $mimePart->getCharset();
         $this->messageData['body'] = $this->mimeMessageInterfaceFactory->create(
             ['parts' => [$mimePart]]


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

As of 2.3.3, Magento's Magento\Framework\Mail\Template\TransportBuilder class can no longer send emails whose "Content-Type" header is set to "text/plain". This is because the TransportBuilder's prepareMessage method does not pass the determined template type to the mimePartInterfaceFactory's create method. When no "type" key is present in the array passed to the create method, the mimePartInterfaceFactory defaults to "text/html".

This pull request simply modifies the prepareMessage method so that it passes the previously determined template type to the mimePartInterfaceFactory's create method.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#26471: TransportBuilder unable to send emails of Content-Type "text/plain" as of 2.3.3

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Define an email template of type "text" via an email_templates.xml file
2. Attempt to use the TransportBuilder's sendMessage() method to send an email based on that template:

```php
$transport = $this->TransportBuilder->setTemplateIdentifier('some_template_id')
	->setTemplateOptions(['area' => \Magento\Framework\App\Area::AREA_ADMINHTML, 'store' => \Magento\Store\Model\Store::DEFAULT_STORE_ID])
	->setFrom("email@domain.com")
	->addTo("email@domain.com")
	->getTransport()
	->sendMessage();
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
